### PR TITLE
Remove unused `sudo: false` in Travis CI settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 rvm:
   - 2.5.1


### PR DESCRIPTION
`sudo: false` has been phased out.
Now the virtual-machine-based Linux is always used.
See: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration